### PR TITLE
Fix `--extra-header` argument not working

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -70,8 +70,8 @@ try {
 
 const extraHTTPHeaders = options.extraHeader.reduce((acc, header) => {
 	const [name, ...value] = header.split(":");
-	return [ ...acc, { [name]: value.join(":") } ];
-}, []);
+	return { ...acc, [name]: value.join(":") };
+}, {});
 
 let output;
 


### PR DESCRIPTION
Puppeteer expects to receive the extra HTTP headers as an object, not an array of objects.

Before this fix, trying to run the CLI with an `--extra-header` argument would throw with the following error:

```bash
➜  pagedjs-cli http://www.google.com --extra-header xx:xx

◶ Loading: http://www.google.comfile:///Users/szilarddobai/.nvm/versions/node/v20.15.1/lib/node_modules/pagedjs-cli/node_modules/puppeteer-core/lib/esm/puppeteer/util/assert.js:25
        throw new Error(message);
              ^

Error: Expected value of header "0" to be String, but "object" is found.
    at assert (file:///Users/szilarddobai/.nvm/versions/node/v20.15.1/lib/node_modules/pagedjs-cli/node_modules/puppeteer-core/lib/esm/puppeteer/util/assert.js:25:15)
    at NetworkManager.setExtraHTTPHeaders (file:///Users/szilarddobai/.nvm/versions/node/v20.15.1/lib/node_modules/pagedjs-cli/node_modules/puppeteer-core/lib/esm/puppeteer/common/NetworkManager.js:106:13)
    at CDPPage.setExtraHTTPHeaders (file:///Users/szilarddobai/.nvm/versions/node/v20.15.1/lib/node_modules/pagedjs-cli/node_modules/puppeteer-core/lib/esm/puppeteer/common/Page.js:448:50)
    at Printer.render (file:///Users/szilarddobai/.nvm/versions/node/v20.15.1/lib/node_modules/pagedjs-cli/src/printer.js:86:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Printer.pdf (file:///Users/szilarddobai/.nvm/versions/node/v20.15.1/lib/node_modules/pagedjs-cli/src/printer.js:270:14)
    at async file:///Users/szilarddobai/.nvm/versions/node/v20.15.1/lib/node_modules/pagedjs-cli/src/cli.js:172:10
```