### PR TITLE
Update README with ARM64 installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Link and build the JS
 ```
 npm install
 npm link
-npm install -g gulp
+npm install gulp
 
 gulp watch
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ npm install -g pagedjs-cli
 ### ARM64
 
 ```
+rm -rf $HOME/.cache/puppeteer/*
 sudo dnf install -y chromium
 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true CHROME_PATH=/usr/bin/chromium-browser PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser npm install
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Render Html to PDFs using [Pagedjs](https://github.com/pagedjs/pagedjs-cli) and 
 npm install -g pagedjs-cli
 ```
 
+### ARM64
+
+```
+sudo dnf install -y chromium
+PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true CHROME_PATH=/usr/bin/chromium-browser PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser npm install
+```
+
 ## Generating a PDF
 
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true CHROME_PATH=/usr/bin/chromium-browser PUPP
 pagedjs-cli ./path/to/index.html -o result.pdf
 ```
 
+### ARM64
+
+```
+PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true CHROME_PATH=/usr/bin/chromium-browser PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser pagedjs-cli ./path/to/index.html -o result.pdf
+```
+
 ## Options
 
 ```
@@ -66,7 +72,7 @@ Link and build the JS
 ```
 npm install
 npm link
-npm install gulp
+npm install -g gulp
 
 gulp watch
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install -g pagedjs-cli
 ```
 rm -rf $HOME/.cache/puppeteer/*
 sudo dnf install -y chromium
-PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true CHROME_PATH=/usr/bin/chromium-browser PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser npm install
+PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true CHROME_PATH=/usr/bin/chromium-browser PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser npm install -g pagedjs-cli
 ```
 
 ## Generating a PDF


### PR DESCRIPTION
Add installation instructions for ARM64 architecture.

(Same as https://github.com/rkwyu/scribd-dl/pull/30, only for whatever reason also need to run it with `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true CHROME_PATH=/usr/bin/chromium-browser PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser pagedjs-cli ./path/to/index.html -o result.pdf`)